### PR TITLE
Update dependencies in pyproject.toml

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 
+## v24.16.1
+
+- Fix dependencies
+
 ## v24.16.0
 
 - Initial release
-- Added codecov config

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,9 @@
 # Changelog
 
-## v24.16.1
+## v24.18.1
 
 - Fix dependencies
 
-## v24.16.0
+## v24.18.0
 
 - Initial release

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ classifiers = [
     "Operating System :: POSIX",
 ]
 keywords = ["automation", "task", "framework", "hashicorp", "vault", "secrets", "otf"]
-dependencies = ["boto3 >= 1.26", "opentaskpy >= v24.13.1"]
+dependencies = ["hvac >= 2.2.0", "opentaskpy >= v24.18.0"]
 description = "Addons for opentaskpy, giving it the ability to read variables from Hashicorp Vault"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "otf-addons-vault"
-version = "v24.18.0"
+version = "v24.18.1"
 authors = [{ name = "Adam McDonagh", email = "adam@elitemonkey.net" }]
 license = { text = "GPLv3" }
 classifiers = [
@@ -48,7 +48,7 @@ dev = [
 profile = 'black'
 
 [tool.bumpver]
-current_version = "v24.18.0"
+current_version = "v24.18.1"
 version_pattern = "vYY.WW.PATCH[-TAG]"
 commit_message = "bump version {old_version} -> {new_version}"
 commit = true


### PR DESCRIPTION
This pull request updates the dependencies in the pyproject.toml file. Specifically, it updates the versions of the "hvac" and "opentaskpy" packages to the latest versions (hvac >= 2.2.0 and opentaskpy >= v24.18.0). 