### PR TITLE
Support v1 KV Secret engine. Fix newline issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v24.18.2
+
+- Fix issue with multiline secrets
+- Set default Vault secret version to v1, while maintaining support for v2 via env var `VAULT_API_VER`
+
 ## v24.18.1
 
 - Fix dependencies

--- a/README.md
+++ b/README.md
@@ -25,6 +25,10 @@ Credentials can be set via config using specific named variables alongside the p
 
 If these variables are set in the environment, then these will be used if not set elsewhere.
 
+# Vault KV Secrets Engine Version
+
+The default version is v1. This can be overridden by setting the environment variable `VAULT_API_VER` to `v2` (or specifying the variable manually)
+
 # Variable Lookup
 
 Variables can be looked up using the `vault` plugin. This is done using standard Jinja2 syntax e.g;

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "otf-addons-vault"
-version = "v24.18.1"
+version = "v24.18.2"
 authors = [{ name = "Adam McDonagh", email = "adam@elitemonkey.net" }]
 license = { text = "GPLv3" }
 classifiers = [
@@ -48,7 +48,7 @@ dev = [
 profile = 'black'
 
 [tool.bumpver]
-current_version = "v24.18.1"
+current_version = "v24.18.2"
 version_pattern = "vYY.WW.PATCH[-TAG]"
 commit_message = "bump version {old_version} -> {new_version}"
 commit = true

--- a/tests/fixtures/vault.py
+++ b/tests/fixtures/vault.py
@@ -41,27 +41,67 @@ def docker_compose_files(root_dir, root_dir_tests) -> list[str]:
 
 
 @pytest.fixture(scope="session")
-def vault_service(docker_services) -> hvac.Client:
+def vault_service(docker_services) -> str:
 
     docker_services.start("vault")
     port = docker_services.port_for("vault", VAULT_PORT)
     address = f"http://{docker_services.docker_ip}:{port}"
+    # Export environment variables
+    os.environ["VAULT_ADDR"] = address
+    os.environ["VAULT_TOKEN"] = VAULT_TOKEN
+
+    return address
+
+
+@pytest.fixture(scope="function")
+def vault_service_v1(vault_service, docker_services) -> hvac.Client:
+
+    # Disable v2 secrets engine and enable v1
+    res = docker_services.execute("vault", "vault", "secrets", "disable", "secret")
+    res = docker_services.execute(
+        "vault", "vault", "secrets", "enable", "-version=1", "-path=secret", "kv"
+    )
 
     # Insert a dummy secret into vault
     client = hvac.Client(
-        url=address,
+        url=vault_service,
         token=VAULT_TOKEN,
     )
+
+    client.secrets.kv.default_kv_version = 1
+
+    create_response = client.secrets.kv.v1.create_or_update_secret(
+        path="my-secret-password",
+        secret=dict(password="Hashi123"),
+    )
+
+    assert create_response.status_code == 204
+
+    return client
+
+
+@pytest.fixture(scope="function")
+def vault_service_v2(vault_service, docker_services) -> hvac.Client:
+
+    # Enable v2 secrets engine
+    res = docker_services.execute("vault", "vault", "secrets", "disable", "secret")
+    res = docker_services.execute(
+        "vault", "vault", "secrets", "enable", "-version=2", "-path=secret", "kv"
+    )
+
+    # Insert a dummy secret into vault
+    client = hvac.Client(
+        url=vault_service,
+        token=VAULT_TOKEN,
+    )
+
+    client.secrets.kv.default_kv_version = 2
     create_response = client.secrets.kv.v2.create_or_update_secret(
         path="my-secret-password",
         secret=dict(password="Hashi123"),
     )
 
     assert not create_response["warnings"]
-
-    # Export environment variables
-    os.environ["VAULT_ADDR"] = address
-    os.environ["VAULT_TOKEN"] = VAULT_TOKEN
 
     return client
 


### PR DESCRIPTION
This pull request adds support for the v1 KV Secret engine and fixes an issue with newline characters when reading secrets and using them in variables